### PR TITLE
Clarify that module name is pyvrs, not vrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ pypi package is built with [this Github Action](https://github.com/facebookresea
 ```
 pip install vrs
 ```
+Note that to import the package, the module is named `pyvrs`, so you will need to write
+```
+import pyvrs
+```
 
 :warning: Note: Work on the Windows version of the PyPI package is currently in progress and will be completed soon. In the meantime, please build the package from the source. Further details can be found in the section below.
 


### PR DESCRIPTION
Some people prefer to use discovery features in their IDEs to learn an API. Such users might never open the linked documentation, and might experience frustration that they `pip install vrs` but must `import pyvrs`. There is no way for them to discover this without reading the documentation first, and even _there_, the fact that the module name `pyvrs` differs from the package name `vrs` is not explicitly obvious! Let's write it down front-and-center!